### PR TITLE
Add GitHub Actions workflow for Go build and test

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,34 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: aoliveti/geohash

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ go.work.sum
 # env file
 .env
 
-./idea
+.idea/
 
 .DS_Store


### PR DESCRIPTION
This commit introduces a workflow to automate Go project builds, tests, and coverage reporting using GitHub Actions. It also fixes the `.gitignore` entry for IntelliJ project files.